### PR TITLE
use node's module resolution to find core icons

### DIFF
--- a/src/util/tokens.ts
+++ b/src/util/tokens.ts
@@ -24,6 +24,7 @@ import {
 import promiseHelper from './promise.js';
 
 const { config, writeTokens } = tokens;
+const require = createRequire(import.meta.url);
 
 const fsReadFilePromise = promisify(readFile);
 const fsWriteFilePromise = promisify(writeFile);
@@ -1367,8 +1368,8 @@ export default (logger: winston.Logger): TokensUtil => {
       source: [
         `${sourceDir}/*.json`,
         path.join(
-          callingPath,
-          'node_modules/@kickstartds/core/source/design-tokens/icons/*.svg'
+          path.dirname(require.resolve('@kickstartds/core/package.json')),
+          'source/design-tokens/icons/*.svg'
         ),
         path.join(callingPath, 'static/icons/*.svg')
       ],
@@ -1391,7 +1392,6 @@ export default (logger: winston.Logger): TokensUtil => {
       return getDefaultStyleDictionary(callingPath, sourceDir);
     }
 
-    const require = createRequire(import.meta.url);
     // eslint-disable-next-line @typescript-eslint/no-var-requires, import/no-dynamic-require
     const sdConfig = require(`${sdConfigPath}`);
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.22--canary.8.77.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install kickstartds@0.2.22--canary.8.77.0
  # or 
  yarn add kickstartds@0.2.22--canary.8.77.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
