### PR TITLE
fix(defaults): always default to rc only for all commands

### DIFF
--- a/src/commands/example/demo.ts
+++ b/src/commands/example/demo.ts
@@ -9,7 +9,7 @@ const demo = new Command('demo')
   .option(
     '--rc-only',
     chalkTemplate`only read configuration from {bold .example-demorc.json}, skip prompts`,
-    false
+    true
   )
   .option(
     '--revert',

--- a/src/commands/schema/dereference.ts
+++ b/src/commands/schema/dereference.ts
@@ -9,6 +9,7 @@ const dereference = new Command('dereference')
   .option(
     '--components-path <path>',
     chalkTemplate`relative path from project root to your components directory, default {bold ./src/components}`,
+    'src/components',
   )
   .option(
     '--schema-domain <domain>',
@@ -17,7 +18,7 @@ const dereference = new Command('dereference')
   .option(
     '--rc-only',
     chalkTemplate`only read configuration from {bold .schema-dereferencerc.json}, skip prompts`,
-    false
+    true
   )
   .option(
     '--revert',

--- a/src/commands/schema/types.ts
+++ b/src/commands/schema/types.ts
@@ -9,6 +9,7 @@ const types = new Command('types')
   .option(
     '--components-path <path>',
     chalkTemplate`relative path from project root to your components directory, default {bold ./src/components}`,
+    'src/components',
   )
   .option(
     '--schema-domain <domain>',
@@ -17,7 +18,7 @@ const types = new Command('types')
   .option(
     '--rc-only',
     chalkTemplate`only read configuration from {bold .schema-typesrc.json}, skip prompts`,
-    false
+    true
   )
   .option(
     '--revert',

--- a/src/commands/tokens/compile.ts
+++ b/src/commands/tokens/compile.ts
@@ -13,7 +13,7 @@ const init = new Command('compile')
   .option(
     '--rc-only',
     chalkTemplate`only read configuration from {bold .tokens-compilerc.json}, skip prompts`,
-    false
+    true
   )
   .option(
     '--revert',

--- a/src/commands/tokens/init.ts
+++ b/src/commands/tokens/init.ts
@@ -13,7 +13,7 @@ const init = new Command('init')
   .option(
     '--rc-only',
     chalkTemplate`only read configuration from {bold .tokens-initrc.json}, skip prompts`,
-    false
+    true
   )
   .option(
     '--revert',

--- a/src/commands/tokens/tofigma.ts
+++ b/src/commands/tokens/tofigma.ts
@@ -13,7 +13,7 @@ const init = new Command('tofigma')
   .option(
     '--rc-only',
     chalkTemplate`only read configuration from {bold .tokens-tofigmarc.json}, skip prompts`,
-    false
+    true
   )
   .option(
     '--revert',


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.40--canary.17.142.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install kickstartds@0.2.40--canary.17.142.0
  # or 
  yarn add kickstartds@0.2.40--canary.17.142.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
