### PR TITLE
fix(tokens): add default token path to token commands

### DIFF
--- a/src/commands/tokens/compile.ts
+++ b/src/commands/tokens/compile.ts
@@ -8,7 +8,8 @@ const init = new Command('compile')
   )
   .option(
     '--token-path <path>',
-    chalkTemplate`relative path from project root to your token dictionary, default {bold ./tokens}`,
+    chalkTemplate`relative path from project root to your token dictionary, default {bold src/token/dictionary}`,
+    'src/token/dictionary',
   )
   .option(
     '--rc-only',

--- a/src/commands/tokens/init.ts
+++ b/src/commands/tokens/init.ts
@@ -8,7 +8,8 @@ const init = new Command('init')
   )
   .option(
     '--token-path <path>',
-    chalkTemplate`relative path from project root to your token dictionary, default {bold ./tokens}`,
+    chalkTemplate`relative path from project root to your token dictionary, default {bold src/token/dictionary}`,
+    'src/token/dictionary',
   )
   .option(
     '--rc-only',

--- a/src/commands/tokens/tofigma.ts
+++ b/src/commands/tokens/tofigma.ts
@@ -8,7 +8,8 @@ const init = new Command('tofigma')
   )
   .option(
     '--token-path <path>',
-    chalkTemplate`relative path from project root to your token dictionary, default {bold ./tokens}`,
+    chalkTemplate`relative path from project root to your token dictionary, default {bold src/token/dictionary}`,
+    'src/token/dictionary',
   )
   .option(
     '--rc-only',

--- a/src/tasks/tokens/compile-task.ts
+++ b/src/tasks/tokens/compile-task.ts
@@ -35,7 +35,7 @@ const {
 } = taskUtilTokens;
 
 const run = async (
-  tokenPath: string = 'tokens',
+  tokenPath: string = 'src/token/dictionary',
   rcOnly: boolean,
   isRevert: boolean,
   shouldCleanup: boolean,

--- a/src/tasks/tokens/init-task.ts
+++ b/src/tasks/tokens/init-task.ts
@@ -31,7 +31,7 @@ const {
 } = taskUtilTokens;
 
 const run = async (
-  tokenPath: string = 'tokens',
+  tokenPath: string = 'src/token/dictionary',
   rcOnly: boolean,
   isRevert: boolean,
   shouldCleanup: boolean,


### PR DESCRIPTION
Uses `src/token/dictionary` as the default now.
<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.40--canary.18.147.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install kickstartds@0.2.40--canary.18.147.0
  # or 
  yarn add kickstartds@0.2.40--canary.18.147.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
