### PR TITLE
fix(token): make location of branding token file configurable

### DIFF
--- a/src/commands/tokens/compile.ts
+++ b/src/commands/tokens/compile.ts
@@ -7,7 +7,7 @@ const init = new Command('compile')
     chalkTemplate`compiles kickstartDS compatible Style Dictionary configuration to css and assets, ready to use in your {#ecff00.bold kickstartDS} Design System`
   )
   .option(
-    '--token-path <path>',
+    '--token-dictionary-path <directory>',
     chalkTemplate`relative path from project root to your token dictionary, default {bold src/token/dictionary}`,
     'src/token/dictionary',
   )
@@ -24,7 +24,7 @@ const init = new Command('compile')
   .option('--cleanup', 'clean up tmp dirs before running', true)
   .option('--debug', 'show debugging output', false)
   .action((options) => {
-    runTask(options.tokenPath, options.rcOnly, options.revert, options.cleanup, options.debug);
+    runTask(options.tokenDictionaryPath, options.rcOnly, options.revert, options.cleanup, options.debug);
   });
 
 export default init;

--- a/src/commands/tokens/init.ts
+++ b/src/commands/tokens/init.ts
@@ -7,7 +7,12 @@ const init = new Command('init')
     chalkTemplate`converts {bold token-primitives.json} to Style Dictionary configuration, ready to use in your {#ecff00.bold kickstartDS} Design System`
   )
   .option(
-    '--token-path <path>',
+    '--branding-token-path <file>',
+    chalkTemplate`relative path from project root to your branding token file, default {bold src/token/branding-token.json}`,
+    'src/token/branding-token.json',
+  )
+  .option(
+    '--token-dictionary-path <directory>',
     chalkTemplate`relative path from project root to your token dictionary, default {bold src/token/dictionary}`,
     'src/token/dictionary',
   )
@@ -25,7 +30,8 @@ const init = new Command('init')
   .option('--debug', 'show debugging output', false)
   .action((options) => {
     runTask(
-      options.tokenPath,
+      options.brandingTokenPath,
+      options.tokenDictionaryPath,
       options.rcOnly,
       options.revert,
       options.cleanup,

--- a/src/commands/tokens/tofigma.ts
+++ b/src/commands/tokens/tofigma.ts
@@ -7,7 +7,7 @@ const init = new Command('tofigma')
     chalkTemplate`transfers {#ecff00.bold kickstartDS} compatible Style Dictionary configuration to {#ecff00.bold kickstartDS} compatible Figma file`
   )
   .option(
-    '--token-path <path>',
+    '--token-dictionary-path <directory>',
     chalkTemplate`relative path from project root to your token dictionary, default {bold src/token/dictionary}`,
     'src/token/dictionary',
   )

--- a/src/tasks/tokens/compile-task.ts
+++ b/src/tasks/tokens/compile-task.ts
@@ -35,7 +35,7 @@ const {
 } = taskUtilTokens;
 
 const run = async (
-  tokenPath: string = 'src/token/dictionary',
+  tokenDictionaryPath: string = 'src/token/dictionary',
   rcOnly: boolean,
   isRevert: boolean,
   shouldCleanup: boolean,
@@ -49,9 +49,9 @@ const run = async (
     shellRequireCommands(requiredCommands);
 
     shell.pushd(`${callingPath}`);
-    if (!shellDirExistsInCwd(tokenPath)) {
+    if (!shellDirExistsInCwd(tokenDictionaryPath)) {
       logger.error(
-        chalkTemplate`no {bold ${tokenPath}} directory found in current directory`
+        chalkTemplate`no {bold ${tokenDictionaryPath}} directory found in current directory`
       );
       shell.exit(1);
     }
@@ -64,8 +64,8 @@ const run = async (
   const compile = async (logger: winston.Logger): Promise<boolean> => {
     logger.info(chalkTemplate`running the {bold compile} subtask`);
 
-    shell.mkdir('-p', `${shell.pwd()}/${dirname(tokenPath)}/`);
-    shell.cp('-r', `${callingPath}/${tokenPath}`, `${shell.pwd()}/${dirname(tokenPath)}/`);
+    shell.mkdir('-p', `${shell.pwd()}/${dirname(tokenDictionaryPath)}/`);
+    shell.cp('-r', `${callingPath}/${tokenDictionaryPath}`, `${shell.pwd()}/${dirname(tokenDictionaryPath)}/`);
 
     logger.info(
       chalkTemplate`getting {bold Style Dictionary} from token files`
@@ -75,11 +75,11 @@ const run = async (
     if (shellFileExistsInCwd(`${callingPath}/sd.config.cjs`)) {
       styleDictionary = await tokensGetStyleDictionary(
         callingPath,
-        tokenPath,
+        tokenDictionaryPath,
         `${callingPath}/sd.config.cjs`
       );
     } else {
-      styleDictionary = tokensGetDefaultStyleDictionary(callingPath, tokenPath);
+      styleDictionary = tokensGetDefaultStyleDictionary(callingPath, tokenDictionaryPath);
     }
 
     logger.info(

--- a/src/tasks/tokens/init-task.ts
+++ b/src/tasks/tokens/init-task.ts
@@ -1,6 +1,6 @@
 import winston from 'winston';
 import shell from 'shelljs';
-import { dirname } from 'path';
+import { dirname, basename } from 'path';
 import chalkTemplate from 'chalk-template';
 import createTask from '../task.js';
 import { StepFunction } from '../../../types/index.js';
@@ -31,7 +31,8 @@ const {
 } = taskUtilTokens;
 
 const run = async (
-  tokenPath: string = 'src/token/dictionary',
+  brandingTokenPath: string = 'src/token/branding-token.json',
+  tokenDictionaryPath: string = 'src/token/dictionary',
   rcOnly: boolean,
   isRevert: boolean,
   shouldCleanup: boolean,
@@ -44,10 +45,10 @@ const run = async (
 
     shellRequireCommands(requiredCommands);
 
-    shell.pushd(`${callingPath}`);
-    if (!shellFileExistsInCwd('token-primitives.json')) {
+    shell.pushd(`${callingPath}/${dirname(brandingTokenPath)}`);
+    if (!shellFileExistsInCwd(basename(brandingTokenPath))) {
       logger.error(
-        chalkTemplate`no {bold token-primitives.json} found in current directory`
+        chalkTemplate`no {bold ${basename(brandingTokenPath)}} found in directory {bold ${dirname(brandingTokenPath)}}`
       );
       shell.exit(1);
     }
@@ -61,12 +62,12 @@ const run = async (
     logger.info(chalkTemplate`running the {bold init} subtask`);
 
 
-    shell.cp(`${callingPath}/token-primitives.json`, shell.pwd());
+    shell.cp(`${callingPath}/${brandingTokenPath}`, shell.pwd());
     await tokensGenerateFromPrimitivesPath(
-      `${shell.pwd()}/token-primitives.json`,
-      `${shell.pwd()}/${tokenPath}`
+      `${shell.pwd()}/${basename(brandingTokenPath)}`,
+      `${shell.pwd()}/${tokenDictionaryPath}`
     );
-    shell.cp(`-r`, `${shell.pwd()}/${tokenPath}`, `${callingPath}/${dirname(tokenPath)}/`);
+    shell.cp(`-r`, `${shell.pwd()}/${tokenDictionaryPath}`, `${callingPath}/${dirname(tokenDictionaryPath)}/`);
 
     logger.info(
       chalkTemplate`finished running the {bold init} subtask successfully`


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>0.2.40--canary.19.148.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install kickstartds@0.2.40--canary.19.148.0
  # or 
  yarn add kickstartds@0.2.40--canary.19.148.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
