### PR TITLE
Add branding token path to CLI as an option

### DIFF
--- a/src/tasks/tokens/init-task.ts
+++ b/src/tasks/tokens/init-task.ts
@@ -61,7 +61,6 @@ const run = async (
   const init = async (logger: winston.Logger): Promise<boolean> => {
     logger.info(chalkTemplate`running the {bold init} subtask`);
 
-
     shell.cp(`${callingPath}/${brandingTokenPath}`, shell.pwd());
     await tokensGenerateFromPrimitivesPath(
       `${shell.pwd()}/${basename(brandingTokenPath)}`,


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v1.0.0-next.1`

<details>
  <summary>Changelog</summary>

  #### 💥 Breaking Change
  
  - feat(schema): add json schema support to CLI [#14](https://github.com/kickstartDS/kickstartDS-cli/pull/14) ([@julrich](https://github.com/julrich))
  
  #### 🚀 Enhancement
  
  - Add branding token path to CLI as an option [#21](https://github.com/kickstartDS/kickstartDS-cli/pull/21) ([@julrich](https://github.com/julrich))
  - chore(assets): add assets needed for testing to repository explicitly [#10](https://github.com/kickstartDS/kickstartDS-cli/pull/10) ([@julrich](https://github.com/julrich))
  
  #### 🐛 Bug Fix
  
  - fix(token): make location of branding token file configurable [#19](https://github.com/kickstartDS/kickstartDS-cli/pull/19) ([@julrich](https://github.com/julrich))
  - fix(tokens): add default token path to token commands [#18](https://github.com/kickstartDS/kickstartDS-cli/pull/18) ([@julrich](https://github.com/julrich))
  - fix(defaults): always default to rc only for all commands [#17](https://github.com/kickstartDS/kickstartDS-cli/pull/17) ([@julrich](https://github.com/julrich))
  - fix(dependencies): move runtime dependencies [#16](https://github.com/kickstartDS/kickstartDS-cli/pull/16) ([@julrich](https://github.com/julrich))
  
  #### ⚠️ Pushed to `next`
  
  - docs(readme): update README.md ([@julrich](https://github.com/julrich))
  - fix(dependencies): update yarn.lock after moving dependencies ([@julrich](https://github.com/julrich))
  - feat(schema): adds working schema dereferencing, not written yet ([@julrich](https://github.com/julrich))
  
  #### Authors: 1
  
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
