### PR TITLE
Fix kickstartDS schema regex

### DIFF
--- a/src/util/schema.ts
+++ b/src/util/schema.ts
@@ -75,7 +75,7 @@ export default (logger: winston.Logger): SchemaUtil => {
     componentsPath: string,
     schemaDomain: string,
   ) => {
-    const kdsUrlRegExp = new RegExp(`^http:\/\/schema\.kickstartds\.com\/([a-z-_]+)\/([a-z-_/]+)\.(?:schema|definitions)\.json$`, 'i');
+    const kdsUrlRegExp = new RegExp(`^http:\/\/schema\.kickstartds\.com\/([a-z-_]+)\/([a-z-_]+)\.(?:schema|definitions)\.json$`, 'i');
 
     const kdsResolver = {
       canRead: new RegExp(`^http:\/\/schema\.kickstartds\.com`, 'i'),


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>1.0.5--canary.28.185.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install kickstartds@1.0.5--canary.28.185.0
  # or 
  yarn add kickstartds@1.0.5--canary.28.185.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->
