### PR TITLE
Fix count of processed schemas in terminal logs

### DIFF
--- a/src/tasks/schema/dereference-task.ts
+++ b/src/tasks/schema/dereference-task.ts
@@ -57,7 +57,7 @@ const run = async (
     const schemaPaths = await fg(`${callingPath}/${componentsPath}/**/*.schema.json`);
     const dereffed = await schemaDereferenceSchemas(schemaPaths, callingPath, componentsPath, schemaDomain);
 
-    logger.info(chalkTemplate`dereffed {bold ${dereffed.length} component definitions}`);
+    logger.info(chalkTemplate`dereffed {bold ${Object.keys(dereffed).length} component definitions}`);
 
     schemaPaths.forEach(async (schemaPath) => {
       const dir = dirname(schemaPath);

--- a/src/tasks/schema/types-task.ts
+++ b/src/tasks/schema/types-task.ts
@@ -59,7 +59,7 @@ const run = async (
     const schemaPaths = await fg(`${callingPath}/${componentsPath}/**/*.schema.json`);
     const dereffed = await schemaDereferenceSchemas(schemaPaths, callingPath, componentsPath, schemaDomain);
 
-    logger.info(chalkTemplate`dereffed {bold ${dereffed.length} component definitions}`);
+    logger.info(chalkTemplate`dereffed {bold ${Object.keys(dereffed).length} component definitions}`);
 
     const types = await schemaGenerateComponentPropTypes(dereffed);
 

--- a/src/util/schema.ts
+++ b/src/util/schema.ts
@@ -3,7 +3,6 @@ import chalkTemplate from 'chalk-template';
 import refParser, { FileInfo } from 'json-schema-ref-parser';
 import merge from 'json-schema-merge-allof';
 import traverse from 'json-schema-traverse';
-import { dirname, basename } from 'path';
 import glob from 'fast-glob';
 import fsExtra from 'fs-extra';
 import { JSONSchema4, JSONSchema7 } from 'json-schema';
@@ -169,7 +168,7 @@ export default (logger: winston.Logger): SchemaUtil => {
     schemas: Record<string, JSONSchema7>
   ) => {
     subCmdLogger.info(
-      chalkTemplate`generating component prop types for {bold ${schemas.length}} component schemas`
+      chalkTemplate`generating component prop types for {bold ${Object.keys(schemas).length}} component schemas`
     );
 
     const convertedTs: Record<string, string> = {};
@@ -184,8 +183,6 @@ export default (logger: winston.Logger): SchemaUtil => {
         )
           return;
         const schema = { ...dereffed } as JSONSchema4;
-        const base = basename(schemaPath, '.json');
-        const dir = dirname(schemaPath);
         schema.title += ' Props';
         removeUnsupportedProps(schema);
         const ts = await compile(schema, schema.title || '', options);


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>2.0.1--canary.32.195.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install kickstartds@2.0.1--canary.32.195.0
  # or 
  yarn add kickstartds@2.0.1--canary.32.195.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v2.0.1-next.0`

<details>
  <summary>Changelog</summary>

  #### 🐛 Bug Fix
  
  - Fix count of processed schemas in terminal logs [#32](https://github.com/kickstartDS/kickstartDS-cli/pull/32) ([@lmestel](https://github.com/lmestel))
  
  #### Authors: 1
  
  - Lukas Mestel ([@lmestel](https://github.com/lmestel))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
