### PR TITLE
Add `sd.config.cjs` path option to token compile task

### DIFF
--- a/src/commands/tokens/compile.ts
+++ b/src/commands/tokens/compile.ts
@@ -9,7 +9,12 @@ const init = new Command('compile')
   .option(
     '--token-dictionary-path <directory>',
     chalkTemplate`relative path from project root to your token dictionary, default {bold src/token/dictionary}`,
-    'src/token/dictionary',
+    'src/token/dictionary'
+  )
+  .option(
+    '--sd-config-path <path>',
+    chalkTemplate`relative path from project root to your Style Dictionary config, default {bold sd.config.cjs}`,
+    'sd.config.cjs'
   )
   .option(
     '--rc-only',
@@ -24,7 +29,14 @@ const init = new Command('compile')
   .option('--cleanup', 'clean up tmp dirs before running', true)
   .option('--debug', 'show debugging output', false)
   .action((options) => {
-    runTask(options.tokenDictionaryPath, options.rcOnly, options.revert, options.cleanup, options.debug);
+    runTask(
+      options.tokenDictionaryPath,
+      options.sdConfigPath,
+      options.rcOnly,
+      options.revert,
+      options.cleanup,
+      options.debug
+    );
   });
 
 export default init;

--- a/src/tasks/tokens/compile-task.ts
+++ b/src/tasks/tokens/compile-task.ts
@@ -13,7 +13,7 @@ const requiredCommands: string[] = [];
 const {
   init: taskInit,
   start: taskStart,
-  util: taskUtil
+  util: taskUtil,
 } = createTask(moduleName, command);
 
 const { shell: taskUtilShell, tokens: taskUtilTokens, getLogger } = taskUtil;
@@ -22,20 +22,21 @@ const {
   helper: {
     requireCommands: shellRequireCommands,
     dirExistsInCwd: shellDirExistsInCwd,
-    fileExistsInCwd: shellFileExistsInCwd
-  }
+    fileExistsInCwd: shellFileExistsInCwd,
+  },
 } = taskUtilShell;
 
 const {
   helper: {
     getDefaultStyleDictionary: tokensGetDefaultStyleDictionary,
     getStyleDictionary: tokensGetStyleDictionary,
-    compileTokens: tokensCompileTokens
-  }
+    compileTokens: tokensCompileTokens,
+  },
 } = taskUtilTokens;
 
 const run = async (
   tokenDictionaryPath: string = 'src/token/dictionary',
+  sdConfigPath: string = 'sd.config.cjs',
   rcOnly: boolean,
   isRevert: boolean,
   shouldCleanup: boolean,
@@ -65,21 +66,28 @@ const run = async (
     logger.info(chalkTemplate`running the {bold compile} subtask`);
 
     shell.mkdir('-p', `${shell.pwd()}/${dirname(tokenDictionaryPath)}/`);
-    shell.cp('-r', `${callingPath}/${tokenDictionaryPath}`, `${shell.pwd()}/${dirname(tokenDictionaryPath)}/`);
+    shell.cp(
+      '-r',
+      `${callingPath}/${tokenDictionaryPath}`,
+      `${shell.pwd()}/${dirname(tokenDictionaryPath)}/`
+    );
 
     logger.info(
       chalkTemplate`getting {bold Style Dictionary} from token files`
     );
 
     let styleDictionary: StyleDictionary.Core;
-    if (shellFileExistsInCwd(`${callingPath}/sd.config.cjs`)) {
+    if (shellFileExistsInCwd(`${callingPath}/${sdConfigPath}`)) {
       styleDictionary = await tokensGetStyleDictionary(
         callingPath,
         tokenDictionaryPath,
-        `${callingPath}/sd.config.cjs`
+        `${callingPath}/${sdConfigPath}`
       );
     } else {
-      styleDictionary = tokensGetDefaultStyleDictionary(callingPath, tokenDictionaryPath);
+      styleDictionary = tokensGetDefaultStyleDictionary(
+        callingPath,
+        tokenDictionaryPath
+      );
     }
 
     logger.info(
@@ -87,7 +95,9 @@ const run = async (
     );
     await tokensCompileTokens(
       styleDictionary,
-      Object.keys(styleDictionary.options.platforms).filter((platform) => styleDictionary.options.platforms[platform].buildPath)
+      Object.keys(styleDictionary.options.platforms).filter(
+        (platform) => styleDictionary.options.platforms[platform].buildPath
+      )
     );
 
     logger.info(
@@ -142,13 +152,13 @@ const run = async (
     revert: StepFunction[];
   } = {
     run: [compile],
-    revert: [compileRevert]
+    revert: [compileRevert],
   };
 
   const compileVariable = 'compile-task';
 
   const cmdLogger = getLogger(moduleName, 'info', true, false, command).child({
-    command
+    command,
   });
   if (isRevert)
     cmdLogger.info(


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v3.0.0-next.5`

<details>
  <summary>Changelog</summary>

  #### 💥 Breaking Change
  
  - Add cms conversions [#41](https://github.com/kickstartDS/cli/pull/41) ([@julrich](https://github.com/julrich))
  - Add type layering capabilities [#37](https://github.com/kickstartDS/cli/pull/37) ([@julrich](https://github.com/julrich))
  
  #### 🚀 Enhancement
  
  - Add `sd.config.cjs` path option to token compile task [#43](https://github.com/kickstartDS/cli/pull/43) ([@julrich](https://github.com/julrich))
  - Add allof merge options to schema tasks where applicable [#40](https://github.com/kickstartDS/cli/pull/40) ([@julrich](https://github.com/julrich))
  
  #### ⚠️ Pushed to `next`
  
  - fix(cms): copy & pasted, wrong naming ([@julrich](https://github.com/julrich))
  - fix(cms): add missing commands ([@julrich](https://github.com/julrich))
  
  #### Authors: 1
  
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
