### PR TITLE
Fix `undefined` count for dereffed schemas in schema dereference task

### DIFF
--- a/src/util/schema.ts
+++ b/src/util/schema.ts
@@ -34,7 +34,7 @@ export default (logger: winston.Logger): SchemaUtil => {
     const dereffedSchemas = await dereference(customSchemaIds, ajv);
 
     subCmdLogger.info(
-      chalkTemplate`dereferencing {bold ${dereffedSchemas.length} component definitions}`
+      chalkTemplate`dereferencing {bold ${Object.keys(dereffedSchemas).length} component definitions}`
     );
     return dereffedSchemas;
   };


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v3.0.0-next.7`

<details>
  <summary>Changelog</summary>

  #### 💥 Breaking Change
  
  - Add cms conversions [#41](https://github.com/kickstartDS/cli/pull/41) ([@julrich](https://github.com/julrich))
  - Add type layering capabilities [#37](https://github.com/kickstartDS/cli/pull/37) ([@julrich](https://github.com/julrich))
  
  #### 🚀 Enhancement
  
  - Add `sd.config.cjs` path option to token compile task [#43](https://github.com/kickstartDS/cli/pull/43) ([@julrich](https://github.com/julrich))
  - Add allof merge options to schema tasks where applicable [#40](https://github.com/kickstartDS/cli/pull/40) ([@julrich](https://github.com/julrich))
  
  #### 🐛 Bug Fix
  
  - Fix `undefined` count for dereffed schemas in schema dereference task [#45](https://github.com/kickstartDS/cli/pull/45) ([@julrich](https://github.com/julrich))
  
  #### ⚠️ Pushed to `next`
  
  - fix(formatting): fix formatting in CLI output ([@julrich](https://github.com/julrich))
  - fix(cms): copy & pasted, wrong naming ([@julrich](https://github.com/julrich))
  - fix(cms): add missing commands ([@julrich](https://github.com/julrich))
  
  #### Authors: 1
  
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
