### PR TITLE
Add ref layering option switch to schema tasks

### DIFF
--- a/src/commands/schema/dereference.ts
+++ b/src/commands/schema/dereference.ts
@@ -20,6 +20,11 @@ const dereference = new Command('dereference')
     chalkTemplate`disable load of default page schema, default {bold false}`
   )
   .option(
+    '--layer-kickstartds-components',
+    chalkTemplate`whether kickstartDS base components should be layered`,
+    true
+  )
+  .option(
     '--rc-only',
     chalkTemplate`only read configuration from {bold .schema-dereferencerc.json}, skip prompts`,
     true
@@ -36,6 +41,7 @@ const dereference = new Command('dereference')
       options.componentsPath,
       options.cmsPath,
       options.defaultPageSchema,
+      options.layerKickstartdsComponents,
       options.rcOnly,
       options.revert,
       options.cleanup,

--- a/src/commands/schema/layer.ts
+++ b/src/commands/schema/layer.ts
@@ -30,6 +30,11 @@ const types = new Command('layer')
     chalkTemplate`disable load of default page schema, default {bold false}`
   )
   .option(
+    '--layer-kickstartds-components',
+    chalkTemplate`whether kickstartDS base components should be layered`,
+    true
+  )
+  .option(
     '--rc-only',
     chalkTemplate`only read configuration from {bold .schema-typesrc.json}, skip prompts`,
     true
@@ -48,6 +53,7 @@ const types = new Command('layer')
       options.typesPath,
       options.mergeSchemas,
       options.defaultPageSchema,
+      options.layerKickstartdsComponents,
       options.rcOnly,
       options.revert,
       options.cleanup,

--- a/src/commands/schema/types.ts
+++ b/src/commands/schema/types.ts
@@ -25,6 +25,11 @@ const types = new Command('types')
     chalkTemplate`disable load of default page schema, default {bold false}`
   )
   .option(
+    '--layer-kickstartds-components',
+    chalkTemplate`whether kickstartDS base components should be layered`,
+    true
+  )
+  .option(
     '--rc-only',
     chalkTemplate`only read configuration from {bold .schema-typesrc.json}, skip prompts`,
     true
@@ -42,6 +47,7 @@ const types = new Command('types')
       options.cmsPath,
       options.mergeSchemas,
       options.defaultPageSchema,
+      options.layerKickstartdsComponents,
       options.rcOnly,
       options.revert,
       options.cleanup,

--- a/src/tasks/schema/dereference-task.ts
+++ b/src/tasks/schema/dereference-task.ts
@@ -32,6 +32,7 @@ const run = async (
   componentsPath: string = 'src/components',
   cmsPath: string,
   defaultPageSchema: boolean = true,
+  layerKickstartdsComponents: boolean = true,
   rcOnly: boolean,
   isRevert: boolean,
   shouldCleanup: boolean,
@@ -57,7 +58,11 @@ const run = async (
       globs.push(`${callingPath}/${cmsPath}/**/*.schema.json`);
     }
     const customSchemaPaths = await fg(globs);
-    const dereffed = await schemaDereferenceSchemas(globs, defaultPageSchema);
+    const dereffed = await schemaDereferenceSchemas(
+      globs,
+      defaultPageSchema,
+      layerKickstartdsComponents
+    );
 
     logger.info(
       chalkTemplate`dereffed {bold ${

--- a/src/tasks/schema/layer-task.ts
+++ b/src/tasks/schema/layer-task.ts
@@ -36,6 +36,7 @@ const run = async (
   typesPath: string = 'src/types',
   mergeSchemas: boolean,
   defaultPageSchema: boolean = true,
+  layerKickstartdsComponents: boolean = true,
   rcOnly: boolean,
   isRevert: boolean,
   shouldCleanup: boolean,
@@ -64,7 +65,8 @@ const run = async (
     const layeredTypes = await schemaLayerComponentPropTypes(
       globs,
       mergeSchemas,
-      defaultPageSchema
+      defaultPageSchema,
+      layerKickstartdsComponents
     );
 
     shell.mkdir('-p', `${shell.pwd()}/${typesPath}/`);

--- a/src/tasks/schema/types-task.ts
+++ b/src/tasks/schema/types-task.ts
@@ -34,6 +34,7 @@ const run = async (
   cmsPath: string,
   mergeSchemas: boolean,
   defaultPageSchema: boolean = true,
+  layerKickstartdsComponents: boolean = true,
   rcOnly: boolean,
   isRevert: boolean,
   shouldCleanup: boolean,
@@ -63,6 +64,7 @@ const run = async (
       globs,
       mergeSchemas,
       defaultPageSchema,
+      layerKickstartdsComponents,
       componentsPath
     );
 

--- a/src/util/schema.ts
+++ b/src/util/schema.ts
@@ -27,11 +27,13 @@ export default (logger: winston.Logger): SchemaUtil => {
 
   const dereferenceSchemas = async (
     schemaGlobs: string[],
-    defaultPageSchema = true
+    defaultPageSchema = true,
+    layerKickstartdsComponents = true
   ) => {
     const ajv = getSchemaRegistry();
     const schemaIds = await processSchemaGlobs(schemaGlobs, ajv, {
       loadPageSchema: defaultPageSchema,
+      layerRefs: layerKickstartdsComponents,
     });
     const customSchemaIds = getCustomSchemaIds(schemaIds);
 
@@ -82,6 +84,7 @@ export default (logger: winston.Logger): SchemaUtil => {
     schemaGlobs: string[],
     mergeAllOf: boolean,
     defaultPageSchema = true,
+    layerKickstartdsComponents = true,
     componentsPath = 'src/components'
   ) => {
     subCmdLogger.info(
@@ -93,6 +96,7 @@ export default (logger: winston.Logger): SchemaUtil => {
       typeResolution: false,
       mergeAllOf: mergeAllOf,
       loadPageSchema: defaultPageSchema,
+      layerRefs: layerKickstartdsComponents,
     });
     const customSchemaIds = getCustomSchemaIds(schemaIds);
 
@@ -132,7 +136,8 @@ export default (logger: winston.Logger): SchemaUtil => {
   const layerComponentPropTypes = async (
     schemaGlobs: string[],
     mergeAllOf: boolean,
-    defaultPageSchema = true
+    defaultPageSchema = true,
+    layerKickstartdsComponents = true
   ) => {
     subCmdLogger.info(
       chalkTemplate`layering component prop types for component schemas`
@@ -143,6 +148,7 @@ export default (logger: winston.Logger): SchemaUtil => {
       typeResolution: false,
       mergeAllOf: mergeAllOf,
       loadPageSchema: defaultPageSchema,
+      layerRefs: layerKickstartdsComponents,
     });
     const kdsSchemaIds = schemaIds.filter((schemaId) =>
       schemaId.includes('schema.kickstartds.com')

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -217,16 +217,19 @@ interface SchemaUtil {
       schemaGlobs: string[],
       mergeAllOf: boolean,
       defaultPageSchema: boolean,
+      layerRefs: boolean,
       componentsPath: string
     ) => Promise<Record<string, string>>;
     layerComponentPropTypes: (
       schemaGlobs: string[],
       mergeAllOf: boolean,
-      defaultPageSchema: boolean
+      defaultPageSchema: boolean,
+      layerRefs: boolean
     ) => Promise<Record<string, string>>;
     dereferenceSchemas: (
       schemaGlobs: string[],
-      defaultPageSchema: boolean
+      defaultPageSchema: boolean,
+      layerRefs: boolean
     ) => Promise<Record<string, JSONSchema.Interface>>;
     toStoryblok: (
       schemaGlobs: string[],


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.3.0--canary.57.306.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install kickstartds@3.3.0--canary.57.306.0
  # or 
  yarn add kickstartds@3.3.0--canary.57.306.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v3.3.0-next.0`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - Add ref layering option switch to schema tasks [#57](https://github.com/kickstartDS/cli/pull/57) ([@julrich](https://github.com/julrich))
  
  #### Authors: 1
  
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
