### PR TITLE
Add naming option for generated TypeScript component interfaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "@kickstartds/jsonschema2staticcms": "^2.9.15",
     "@kickstartds/jsonschema2stackbit": "^1.3.14",
     "@kickstartds/jsonschema2storyblok": "^1.5.20",
-    "@kickstartds/jsonschema2types": "^1.1.37",
+    "@kickstartds/jsonschema2types": "^1.2.0",
     "@kickstartds/jsonschema2uniform": "^1.4.2",
     "@stackbit/types": "^0.10.14",
     "@types/byline": "^4.2.33",

--- a/src/commands/schema/types.ts
+++ b/src/commands/schema/types.ts
@@ -30,6 +30,11 @@ const types = new Command('types')
     true
   )
   .option(
+    '--type-naming <naming>',
+    chalkTemplate`whether types should be named by "title" or "id"`,
+    'title'
+  )
+  .option(
     '--rc-only',
     chalkTemplate`only read configuration from {bold .schema-typesrc.json}, skip prompts`,
     true
@@ -48,6 +53,7 @@ const types = new Command('types')
       options.mergeSchemas,
       options.defaultPageSchema,
       options.layerKickstartdsComponents,
+      options.typeNaming,
       options.rcOnly,
       options.revert,
       options.cleanup,

--- a/src/tasks/schema/types-task.ts
+++ b/src/tasks/schema/types-task.ts
@@ -35,6 +35,7 @@ const run = async (
   mergeSchemas: boolean,
   defaultPageSchema: boolean = true,
   layerKickstartdsComponents: boolean = true,
+  typeNaming: string = 'title',
   rcOnly: boolean,
   isRevert: boolean,
   shouldCleanup: boolean,
@@ -65,6 +66,7 @@ const run = async (
       mergeSchemas,
       defaultPageSchema,
       layerKickstartdsComponents,
+      typeNaming,
       componentsPath
     );
 

--- a/src/util/schema.ts
+++ b/src/util/schema.ts
@@ -18,6 +18,8 @@ import type { IStoryblokBlock } from '@kickstartds/jsonschema2storyblok';
 import type { IStaticCmsField } from '@kickstartds/jsonschema2staticcms';
 import { pascalCase } from 'change-case';
 import type { DataModel, ObjectModel, PageModel } from '@stackbit/types';
+import { defaultTitleFunction } from '@kickstartds/jsonschema2types';
+import { JSONSchema4 } from 'json-schema';
 
 const renderImportName = (schemaId: string) =>
   `${pascalCase(getSchemaName(schemaId))}Props`;
@@ -85,6 +87,7 @@ export default (logger: winston.Logger): SchemaUtil => {
     mergeAllOf: boolean,
     defaultPageSchema = true,
     layerKickstartdsComponents = true,
+    typeNaming = 'title',
     componentsPath = 'src/components'
   ) => {
     subCmdLogger.info(
@@ -121,13 +124,18 @@ export default (logger: winston.Logger): SchemaUtil => {
             getSchemaName(schemaId)
           )}Props'`;
 
+    const idTitleFunction = (schema: JSONSchema4): string =>
+      `${pascalCase(getSchemaName(schema.$id))}Props`;
+
     const convertedTs = await (
       await import('@kickstartds/jsonschema2types')
     ).createTypes(
       customSchemaIds,
       renderImportName,
       renderImportStatement,
-      ajv
+      ajv,
+      {},
+      typeNaming === 'id' ? idTitleFunction : defaultTitleFunction
     );
 
     return convertedTs;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -218,6 +218,7 @@ interface SchemaUtil {
       mergeAllOf: boolean,
       defaultPageSchema: boolean,
       layerRefs: boolean,
+      typeNaming: string,
       componentsPath: string
     ) => Promise<Record<string, string>>;
     layerComponentPropTypes: (

--- a/yarn.lock
+++ b/yarn.lock
@@ -925,6 +925,20 @@
     json-schema-traverse "^1.0.0"
     jsonpointer "~5.0.1"
 
+"@kickstartds/jsonschema-utils@3.4.3":
+  version "3.4.3"
+  resolved "https://registry.npmjs.org/@kickstartds/jsonschema-utils/-/jsonschema-utils-3.4.3.tgz#b16025fb7f4e76c843d33cd159e49b71c4b12640"
+  integrity sha512-2rdTBz1psnSngP1fjy50GWy9jms0z4L7egmWhcqSkXsJesccblsWsUC+2i2Dg+0WIVsB+SjMLIxteLr+5Kyhcw==
+  dependencies:
+    "@bcherny/json-schema-ref-parser" "10.0.5-fork"
+    ajv "^8.12.0"
+    change-case "^5.0.2"
+    directed-graph-typed "~1.52.0"
+    fast-glob "^3.2.12"
+    import-meta-resolve "~3.0.0"
+    json-schema-traverse "^1.0.0"
+    jsonpointer "~5.0.1"
+
 "@kickstartds/jsonschema2stackbit@^1.3.14":
   version "1.3.14"
   resolved "https://registry.npmjs.org/@kickstartds/jsonschema2stackbit/-/jsonschema2stackbit-1.3.14.tgz#d3f27bfa02b1354847d9aa246cf64293f6f8d298"
@@ -954,13 +968,13 @@
     object-traversal "^1.0.1"
     uuid "~9.0.0"
 
-"@kickstartds/jsonschema2types@^1.1.37":
-  version "1.1.37"
-  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2types/-/jsonschema2types-1.1.37.tgz#91b820d94c5dbec49ebe99788334c5c2f476eb64"
-  integrity sha512-aSrfryJeHywO2sQh+M/Pr60tvl+CGqs59Irq8+EhNkZ/nIeMZDdjYltqDy1jG+5/Tbth0yi95+0d6Cx/qOkkdA==
+"@kickstartds/jsonschema2types@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2types/-/jsonschema2types-1.2.0.tgz#0f1d67d11679996f1fc24bb46cc8d3267f204d5f"
+  integrity sha512-xAiSwFzMr7kae59a3EXzkn9Iznm7Khp3rXm9oA29IaXKT/lC0rq9JPepwtxsr/AjkwY+YyKrq+Kxsl8pdT1QWA==
   dependencies:
     "@kickstartds/json-schema-to-typescript" "~13.1.20"
-    "@kickstartds/jsonschema-utils" "3.0.11"
+    "@kickstartds/jsonschema-utils" "3.4.3"
     ajv "^8.12.0"
     object-traversal "^1.0.1"
 


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.4.0--canary.58.311.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install kickstartds@3.4.0--canary.58.311.0
  # or 
  yarn add kickstartds@3.4.0--canary.58.311.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v3.3.0-next.1`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - Add naming option for generated TypeScript component interfaces [#58](https://github.com/kickstartDS/cli/pull/58) ([@julrich](https://github.com/julrich))
  - Add ref layering option switch to schema tasks [#57](https://github.com/kickstartDS/cli/pull/57) ([@julrich](https://github.com/julrich))
  
  #### Authors: 1
  
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
