### PR TITLE
Add task to create default objects for schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@commitlint/config-conventional": "^16.2.1",
     "@kickstartds/eslint-config": "^1.2.0",
     "@kickstartds/style-dictionary": "^4.0.2",
-    "@kickstartds/jsonschema-utils": "^3.0.11",
+    "@kickstartds/jsonschema-utils": "^3.5.0",
     "@kickstartds/jsonschema2staticcms": "^2.9.15",
     "@kickstartds/jsonschema2stackbit": "^1.3.14",
     "@kickstartds/jsonschema2storyblok": "^1.5.20",

--- a/package.json
+++ b/package.json
@@ -101,12 +101,12 @@
     "@commitlint/config-conventional": "^16.2.1",
     "@kickstartds/eslint-config": "^1.2.0",
     "@kickstartds/style-dictionary": "^4.0.2",
-    "@kickstartds/jsonschema-utils": "^3.5.0",
-    "@kickstartds/jsonschema2staticcms": "^2.9.15",
-    "@kickstartds/jsonschema2stackbit": "^1.3.14",
-    "@kickstartds/jsonschema2storyblok": "^1.5.20",
-    "@kickstartds/jsonschema2types": "^1.2.0",
-    "@kickstartds/jsonschema2uniform": "^1.4.2",
+    "@kickstartds/jsonschema-utils": "^3.6.1",
+    "@kickstartds/jsonschema2staticcms": "^2.9.35",
+    "@kickstartds/jsonschema2stackbit": "^1.7.4",
+    "@kickstartds/jsonschema2storyblok": "^1.6.5",
+    "@kickstartds/jsonschema2types": "^1.2.3",
+    "@kickstartds/jsonschema2uniform": "^1.4.22",
     "@stackbit/types": "^0.10.14",
     "@types/byline": "^4.2.33",
     "@types/dockerode": "^3.3.9",
@@ -135,11 +135,11 @@
   "peerDependencies": {
     "@kickstartds/core": "^4.0.2",
     "@kickstartds/style-dictionary": "^4.0.2",
-    "@kickstartds/jsonschema-utils": "^3.0.11",
-    "@kickstartds/jsonschema2staticcms": "^2.9.15",
-    "@kickstartds/jsonschema2stackbit": "^1.3.14",
-    "@kickstartds/jsonschema2storyblok": "^1.5.20",
-    "@kickstartds/jsonschema2types": "^1.1.37",
-    "@kickstartds/jsonschema2uniform": "^1.4.2"
+    "@kickstartds/jsonschema-utils": "^3.6.1",
+    "@kickstartds/jsonschema2staticcms": "^2.9.35",
+    "@kickstartds/jsonschema2stackbit": "^1.7.4",
+    "@kickstartds/jsonschema2storyblok": "^1.6.5",
+    "@kickstartds/jsonschema2types": "^1.2.3",
+    "@kickstartds/jsonschema2uniform": "^1.4.22"
   }
 }

--- a/src/commands/schema.ts
+++ b/src/commands/schema.ts
@@ -3,6 +3,7 @@ import { getLogger } from '../logging.js';
 import types from './schema/types.js';
 import layer from './schema/layer.js';
 import dereference from './schema/dereference.js';
+import defaults from './schema/defaults.js';
 
 const logger = getLogger('schema');
 
@@ -12,4 +13,5 @@ program
   .addCommand(types)
   .addCommand(dereference)
   .addCommand(layer)
+  .addCommand(defaults)
   .parse(process.argv);

--- a/src/commands/schema/defaults.ts
+++ b/src/commands/schema/defaults.ts
@@ -1,0 +1,52 @@
+import { Command } from 'commander';
+import chalkTemplate from 'chalk-template';
+import runTask from '../../tasks/schema/defaults-task.js';
+
+const dereference = new Command('defaults')
+  .description(
+    chalkTemplate`Creates default objects for {bold JSON Schema} component definitions`
+  )
+  .option(
+    '--components-path <path>',
+    chalkTemplate`relative path from project root to your components directory, default {bold ./src/components}`,
+    'src/components'
+  )
+  .option(
+    '--cms-path <path>',
+    chalkTemplate`relative path from project root to your cms specific components directory, default {bold ./src/components}`
+  )
+  .option(
+    '--no-default-page-schema',
+    chalkTemplate`disable load of default page schema, default {bold false}`
+  )
+  .option(
+    '--layer-kickstartds-components',
+    chalkTemplate`whether kickstartDS base components should be layered`,
+    true
+  )
+  .option(
+    '--rc-only',
+    chalkTemplate`only read configuration from {bold .schema-dereferencerc.json}, skip prompts`,
+    true
+  )
+  .option(
+    '--revert',
+    chalkTemplate`revert command defined by {bold .schema-dereferencerc.json}, implies {bold --rc-only}`,
+    false
+  )
+  .option('--cleanup', 'clean up tmp dirs before running', true)
+  .option('--debug', 'show debugging output', false)
+  .action((options) => {
+    runTask(
+      options.componentsPath,
+      options.cmsPath,
+      options.defaultPageSchema,
+      options.layerKickstartdsComponents,
+      options.rcOnly,
+      options.revert,
+      options.cleanup,
+      options.debug
+    );
+  });
+
+export default dereference;

--- a/src/commands/schema/defaults.ts
+++ b/src/commands/schema/defaults.ts
@@ -2,7 +2,7 @@ import { Command } from 'commander';
 import chalkTemplate from 'chalk-template';
 import runTask from '../../tasks/schema/defaults-task.js';
 
-const dereference = new Command('defaults')
+const defaults = new Command('defaults')
   .description(
     chalkTemplate`Creates default objects for {bold JSON Schema} component definitions`
   )
@@ -26,12 +26,12 @@ const dereference = new Command('defaults')
   )
   .option(
     '--rc-only',
-    chalkTemplate`only read configuration from {bold .schema-dereferencerc.json}, skip prompts`,
+    chalkTemplate`only read configuration from {bold .schema-defaultsrc.json}, skip prompts`,
     true
   )
   .option(
     '--revert',
-    chalkTemplate`revert command defined by {bold .schema-dereferencerc.json}, implies {bold --rc-only}`,
+    chalkTemplate`revert command defined by {bold .schema-defaultsrc.json}, implies {bold --rc-only}`,
     false
   )
   .option('--cleanup', 'clean up tmp dirs before running', true)
@@ -49,4 +49,4 @@ const dereference = new Command('defaults')
     );
   });
 
-export default dereference;
+export default defaults;

--- a/src/tasks/schema/defaults-task.ts
+++ b/src/tasks/schema/defaults-task.ts
@@ -5,6 +5,7 @@ import chalkTemplate from 'chalk-template';
 import createTask from '../task.js';
 import { StepFunction } from '../../../types/index.js';
 import fsExtra from 'fs-extra';
+import { pascalCase } from 'change-case';
 
 const writeFile = fsExtra.writeFile;
 
@@ -87,8 +88,10 @@ const run = async (
         const dir = dirname(schemaPath);
 
         return writeFile(
-          `${dir}/${base}.defaults.json`,
-          JSON.stringify(defaults[schemaId], null, 2)
+          `${dir}/${pascalCase(
+            base.replace(/\.(schema|definitions)$/, '')
+          )}Defaults.ts`,
+          defaults[schemaId]
         );
       })
     );

--- a/src/tasks/schema/defaults-task.ts
+++ b/src/tasks/schema/defaults-task.ts
@@ -1,0 +1,152 @@
+import winston from 'winston';
+import { dirname, basename } from 'path';
+import fg from 'fast-glob';
+import chalkTemplate from 'chalk-template';
+import createTask from '../task.js';
+import { StepFunction } from '../../../types/index.js';
+import fsExtra from 'fs-extra';
+
+const writeFile = fsExtra.writeFile;
+
+const moduleName = 'schema';
+const command = 'defaults';
+const requiredCommands: string[] = [];
+
+const {
+  init: taskInit,
+  start: taskStart,
+  util: taskUtil,
+} = createTask(moduleName, command);
+
+const { shell: taskUtilShell, schema: taskUtilSchema, getLogger } = taskUtil;
+
+const {
+  helper: { requireCommands: shellRequireCommands },
+} = taskUtilShell;
+
+const {
+  helper: { createDefaultObjects: schemaCreateDefaultObjects },
+} = taskUtilSchema;
+
+const run = async (
+  componentsPath: string = 'src/components',
+  cmsPath: string,
+  defaultPageSchema: boolean = true,
+  layerKickstartdsComponents: boolean = true,
+  rcOnly: boolean,
+  isRevert: boolean,
+  shouldCleanup: boolean,
+  debugActive: boolean
+): Promise<void> => {
+  const callingPath: string = process.cwd();
+
+  const check = async (logger: winston.Logger): Promise<boolean> => {
+    logger.info('checking prerequesites before starting');
+
+    shellRequireCommands(requiredCommands);
+
+    logger.info('prerequesites met, starting');
+    return true;
+  };
+
+  const defaults = async (logger: winston.Logger): Promise<boolean> => {
+    logger.info(chalkTemplate`running the {bold defaults} subtask`);
+
+    const customSchemaGlob = `${callingPath}/${componentsPath}/**/*.schema.json`;
+    const globs = [customSchemaGlob];
+    if (cmsPath) {
+      globs.push(`${callingPath}/${cmsPath}/**/*.schema.json`);
+    }
+    const customSchemaPaths = await fg(globs);
+    const defaults = await schemaCreateDefaultObjects(
+      globs,
+      defaultPageSchema,
+      layerKickstartdsComponents
+    );
+
+    logger.info(
+      chalkTemplate`created {bold ${
+        Object.keys(defaults).length
+      } schema default objects}`
+    );
+
+    await Promise.all(
+      Object.keys(defaults).map(async (schemaId) => {
+        const schemaPath = customSchemaPaths.find(
+          (schemaPath) =>
+            schemaPath.endsWith(
+              `/${schemaId.split('/').pop()}` || 'NO MATCH'
+            ) &&
+            (schemaId.startsWith('http://cms.')
+              ? !schemaPath.includes('node_modules')
+              : true)
+        );
+        if (!schemaPath)
+          throw new Error("Couldn't find matching schema path for schema $id");
+        const base = basename(schemaPath, '.json');
+        const dir = dirname(schemaPath);
+
+        return writeFile(
+          `${dir}/${base}.defaults.json`,
+          JSON.stringify(defaults[schemaId], null, 2)
+        );
+      })
+    );
+
+    logger.info(
+      chalkTemplate`finished running the {bold defaults} subtask successfully`
+    );
+    return true;
+  };
+
+  const defaultsRevert = async (logger: winston.Logger): Promise<boolean> => {
+    logger.info(
+      chalkTemplate`{bold reverting} running the {bold defaults} subtask`
+    );
+
+    // TODO implement revert subtask
+
+    logger.info(
+      chalkTemplate`{bold reverting} running the {bold defaults} subtask finished successfully`
+    );
+    return true;
+  };
+
+  const checks: StepFunction[] = [check];
+
+  const tasks: {
+    run: StepFunction[];
+    revert: StepFunction[];
+  } = {
+    run: [defaults],
+    revert: [defaultsRevert],
+  };
+
+  const defaultsVariable = 'defaults-task';
+
+  const cmdLogger = getLogger(moduleName, 'info', true, false, command).child({
+    command,
+  });
+  if (isRevert)
+    cmdLogger.info(
+      chalkTemplate`starting: {bold reverting} defaults command with defaults variable {bold ${defaultsVariable}}`
+    );
+  else
+    cmdLogger.info(
+      chalkTemplate`starting: defaults command with defaults variable {bold ${defaultsVariable}}`
+    );
+
+  await taskInit(null, rcOnly, isRevert, shouldCleanup, debugActive);
+  await taskStart(defaultsVariable, checks, tasks.run, tasks.revert);
+
+  if (isRevert)
+    cmdLogger.info(
+      chalkTemplate`finished: {bold reverting} defaults command with defaults variable {bold ${defaultsVariable}}`
+    );
+  else
+    cmdLogger.info(
+      chalkTemplate`finished: defaults command with defaults variable {bold ${defaultsVariable}}`
+    );
+};
+
+export default run;

--- a/src/util/schema.ts
+++ b/src/util/schema.ts
@@ -272,7 +272,9 @@ export default defaults;`;
     components: string[]
   ) => {
     const ajv = getSchemaRegistry();
-    const schemaIds = await processSchemaGlobs(schemaGlobs, ajv);
+    const schemaIds = await processSchemaGlobs(schemaGlobs, ajv, {
+      hideCmsFields: true,
+    });
     const customSchemaIds = getCustomSchemaIds(schemaIds);
 
     const result = await (
@@ -309,7 +311,9 @@ export default defaults;`;
     globals: string[]
   ) => {
     const ajv = getSchemaRegistry();
-    const schemaIds = await processSchemaGlobs(schemaGlobs, ajv);
+    const schemaIds = await processSchemaGlobs(schemaGlobs, ajv, {
+      hideCmsFields: true,
+    });
     const customSchemaIds = getCustomSchemaIds(schemaIds);
 
     const result = await (
@@ -340,7 +344,9 @@ export default defaults;`;
     components: string[]
   ) => {
     const ajv = getSchemaRegistry();
-    const schemaIds = await processSchemaGlobs(schemaGlobs, ajv);
+    const schemaIds = await processSchemaGlobs(schemaGlobs, ajv, {
+      hideCmsFields: true,
+    });
     const customSchemaIds = getCustomSchemaIds(schemaIds);
 
     const result = await (
@@ -379,7 +385,9 @@ export default defaults;`;
     globals: string[]
   ) => {
     const ajv = getSchemaRegistry();
-    const schemaIds = await processSchemaGlobs(schemaGlobs, ajv);
+    const schemaIds = await processSchemaGlobs(schemaGlobs, ajv, {
+      hideCmsFields: true,
+    });
     const customSchemaIds = getCustomSchemaIds(schemaIds);
 
     const result = await (

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -232,6 +232,11 @@ interface SchemaUtil {
       defaultPageSchema: boolean,
       layerRefs: boolean
     ) => Promise<Record<string, JSONSchema.Interface>>;
+    createDefaultObjects: (
+      schemaGlobs: string[],
+      defaultPageSchema: boolean,
+      layerRefs: boolean
+    ) => Promise<Record<string, unknown>>;
     toStoryblok: (
       schemaGlobs: string[],
       templates: string[],

--- a/yarn.lock
+++ b/yarn.lock
@@ -878,6 +878,16 @@
   resolved "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz#9df03bbd7c696a5c58885c34aa06da41c8543796"
   integrity sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==
 
+"@kickstartds/cambria@1.0.5":
+  version "1.0.5"
+  resolved "https://registry.npmjs.org/@kickstartds/cambria/-/cambria-1.0.5.tgz#3cf76d61b0a1f2a53bf27af7622d97d6165450fd"
+  integrity sha512-W+KtExbtA9yqZyBPRB4tWlHfatkrMOkGhzh7+BBEfS+cpA17SEvBiGKHRPnoksiUKpsB22FNy7UXZqwZhJF3vw==
+  dependencies:
+    fast-json-patch "^3.1.1"
+    graphlib "^2.1.8"
+    js-yaml "^4.1.0"
+    to-json-schema "^0.2.5"
+
 "@kickstartds/eslint-config@^1.2.0":
   version "1.2.0"
   resolved "https://registry.npmjs.org/@kickstartds/eslint-config/-/eslint-config-1.2.0.tgz#6834526b0cb3ce5ca38901eaa1aa9daa355db89e"
@@ -911,7 +921,7 @@
     mkdirp "^1.0.4"
     prettier "^2.6.2"
 
-"@kickstartds/jsonschema-utils@3.0.11", "@kickstartds/jsonschema-utils@^3.0.11":
+"@kickstartds/jsonschema-utils@3.0.11":
   version "3.0.11"
   resolved "https://registry.npmjs.org/@kickstartds/jsonschema-utils/-/jsonschema-utils-3.0.11.tgz#c98a1e42fe1548d2e069e60d813d3960f287a6b0"
   integrity sha512-miE3/MJDpbItVKcpeG9xnPgzDtmB/1sL7I5h1pU9BGVa4su1vLeOBAtl+vneOFYQkxOwvKzuHeZaJiCWS8nIww==
@@ -931,6 +941,21 @@
   integrity sha512-2rdTBz1psnSngP1fjy50GWy9jms0z4L7egmWhcqSkXsJesccblsWsUC+2i2Dg+0WIVsB+SjMLIxteLr+5Kyhcw==
   dependencies:
     "@bcherny/json-schema-ref-parser" "10.0.5-fork"
+    ajv "^8.12.0"
+    change-case "^5.0.2"
+    directed-graph-typed "~1.52.0"
+    fast-glob "^3.2.12"
+    import-meta-resolve "~3.0.0"
+    json-schema-traverse "^1.0.0"
+    jsonpointer "~5.0.1"
+
+"@kickstartds/jsonschema-utils@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.npmjs.org/@kickstartds/jsonschema-utils/-/jsonschema-utils-3.5.0.tgz#01791974464bb9b19e6b412c8c7dee24121e8ac4"
+  integrity sha512-iVAvqiRlYyM5df1/fcVTBEDRArJW9TFsHo4vp+3Btx4RALwVvkivCFudhkbNYuE2qkpp6sCPAnhVg5Df6Em9VQ==
+  dependencies:
+    "@bcherny/json-schema-ref-parser" "10.0.5-fork"
+    "@kickstartds/cambria" "1.0.5"
     ajv "^8.12.0"
     change-case "^5.0.2"
     directed-graph-typed "~1.52.0"
@@ -3772,6 +3797,11 @@ fast-json-parse@^1.0.3:
   resolved "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz#43e5c61ee4efa9265633046b770fb682a7577c4d"
   integrity sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw==
 
+fast-json-patch@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"
+  integrity sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==
+
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -4262,6 +4292,13 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4:
   version "4.2.11"
   resolved "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
   integrity sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==
+
+graphlib@^2.1.8:
+  version "2.1.8"
+  resolved "https://registry.npmjs.org/graphlib/-/graphlib-2.1.8.tgz#5761d414737870084c92ec7b5dbcb0592c9d35da"
+  integrity sha512-jcLLfkpoVGmH7/InMC/1hIvOPSUh38oJtGhvrOFGzioE1DZ+0YW16RgmOJhHiuWTvGiJQ9Z1Ik43JvkRPRvE+A==
+  dependencies:
+    lodash "^4.17.15"
 
 graphql-compose@^9.0.10:
   version "9.0.10"
@@ -5172,10 +5209,20 @@ lodash.get@^4:
   resolved "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==
 
+lodash.isequal@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz#415c4478f2bcc30120c22ce10ed3226f7d3e18e0"
+  integrity sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==
+
 lodash.isplainobject@^4.0.6:
   version "4.0.6"
   resolved "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==
+
+lodash.keys@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.npmjs.org/lodash.keys/-/lodash.keys-4.2.0.tgz#a08602ac12e4fb83f91fc1fb7a360a4d9ba35205"
+  integrity sha512-J79MkJcp7Df5mizHiVNpjoHXLi4HLjh9VLS/M7lQSGoQ+0oQ+lWEigREkqKyizPB1IawvQLLKY8mzEcm1tkyxQ==
 
 lodash.map@^4.5.1, lodash.map@^4.6.0:
   version "4.6.0"
@@ -5202,6 +5249,11 @@ lodash.mergewith@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.2.tgz#617121f89ac55f59047c7aec1ccd6654c6590f55"
   integrity sha512-GK3g5RPZWTRSeLSpgP8Xhra+pnjBC56q9FZYe1d5RN3TJ35dbkGy3YqBSMbyCrlbi+CM9Z3Jk5yTL7RCsqboyQ==
 
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+  integrity sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==
+
 lodash.truncate@^4.4.2:
   version "4.4.2"
   resolved "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz#5a350da0b1113b837ecfffd5812cbe58d6eae193"
@@ -5211,6 +5263,16 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==
+
+lodash.without@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.npmjs.org/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
+  integrity sha512-M3MefBwfDhgKgINVuBJCO1YR3+gf6s9HNJsIiZ/Ru77Ws6uTb9eBuvrkpzO+9iLoAaRodGuq7tyrPCx+74QYGQ==
+
+lodash.xor@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/lodash.xor/-/lodash.xor-4.5.0.tgz#4d48ed7e98095b0632582ba714d3ff8ae8fb1db6"
+  integrity sha512-sVN2zimthq7aZ5sPGXnSz32rZPuqcparVW50chJQe+mzTYV+IsxSsl/2gnkWWE2Of7K3myBQBqtLKOUEHJKRsQ==
 
 lodash@4.17.21, lodash@^4.11.2, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4:
   version "4.17.21"
@@ -7326,6 +7388,18 @@ to-fast-properties@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz#dc5e698cbd079265bc73e0377681a4e4e83f616e"
   integrity sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==
+
+to-json-schema@^0.2.5:
+  version "0.2.5"
+  resolved "https://registry.npmjs.org/to-json-schema/-/to-json-schema-0.2.5.tgz#ef3c3f11ad64460dcfbdbafd0fd525d69d62a98f"
+  integrity sha512-jP1ievOee8pec3tV9ncxLSS48Bnw7DIybgy112rhMCEhf3K4uyVNZZHr03iQQBzbV5v5Hos+dlZRRyk6YSMNDw==
+  dependencies:
+    lodash.isequal "^4.5.0"
+    lodash.keys "^4.2.0"
+    lodash.merge "^4.6.2"
+    lodash.omit "^4.5.0"
+    lodash.without "^4.4.0"
+    lodash.xor "^4.5.0"
 
 to-regex-range@^5.0.1:
   version "5.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -921,38 +921,10 @@
     mkdirp "^1.0.4"
     prettier "^2.6.2"
 
-"@kickstartds/jsonschema-utils@3.0.11":
-  version "3.0.11"
-  resolved "https://registry.npmjs.org/@kickstartds/jsonschema-utils/-/jsonschema-utils-3.0.11.tgz#c98a1e42fe1548d2e069e60d813d3960f287a6b0"
-  integrity sha512-miE3/MJDpbItVKcpeG9xnPgzDtmB/1sL7I5h1pU9BGVa4su1vLeOBAtl+vneOFYQkxOwvKzuHeZaJiCWS8nIww==
-  dependencies:
-    "@bcherny/json-schema-ref-parser" "10.0.5-fork"
-    ajv "^8.12.0"
-    change-case "^5.0.2"
-    directed-graph-typed "~1.52.0"
-    fast-glob "^3.2.12"
-    import-meta-resolve "~3.0.0"
-    json-schema-traverse "^1.0.0"
-    jsonpointer "~5.0.1"
-
-"@kickstartds/jsonschema-utils@3.4.3":
-  version "3.4.3"
-  resolved "https://registry.npmjs.org/@kickstartds/jsonschema-utils/-/jsonschema-utils-3.4.3.tgz#b16025fb7f4e76c843d33cd159e49b71c4b12640"
-  integrity sha512-2rdTBz1psnSngP1fjy50GWy9jms0z4L7egmWhcqSkXsJesccblsWsUC+2i2Dg+0WIVsB+SjMLIxteLr+5Kyhcw==
-  dependencies:
-    "@bcherny/json-schema-ref-parser" "10.0.5-fork"
-    ajv "^8.12.0"
-    change-case "^5.0.2"
-    directed-graph-typed "~1.52.0"
-    fast-glob "^3.2.12"
-    import-meta-resolve "~3.0.0"
-    json-schema-traverse "^1.0.0"
-    jsonpointer "~5.0.1"
-
-"@kickstartds/jsonschema-utils@^3.5.0":
-  version "3.5.0"
-  resolved "https://registry.npmjs.org/@kickstartds/jsonschema-utils/-/jsonschema-utils-3.5.0.tgz#01791974464bb9b19e6b412c8c7dee24121e8ac4"
-  integrity sha512-iVAvqiRlYyM5df1/fcVTBEDRArJW9TFsHo4vp+3Btx4RALwVvkivCFudhkbNYuE2qkpp6sCPAnhVg5Df6Em9VQ==
+"@kickstartds/jsonschema-utils@3.6.1", "@kickstartds/jsonschema-utils@^3.6.1":
+  version "3.6.1"
+  resolved "https://registry.npmjs.org/@kickstartds/jsonschema-utils/-/jsonschema-utils-3.6.1.tgz#b692e56bfeae8c8bf8961ba3f86e358a811da198"
+  integrity sha512-Ke5adEzH0s5XXYJmBLGIIGBXAl0rWHaiOoFE0LmZUD1S8rTgS7VN5hoW6OWj35uXcWRVwC0sdkPFnKsVCxM+rQ==
   dependencies:
     "@bcherny/json-schema-ref-parser" "10.0.5-fork"
     "@kickstartds/cambria" "1.0.5"
@@ -964,51 +936,52 @@
     json-schema-traverse "^1.0.0"
     jsonpointer "~5.0.1"
 
-"@kickstartds/jsonschema2stackbit@^1.3.14":
-  version "1.3.14"
-  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2stackbit/-/jsonschema2stackbit-1.3.14.tgz#d3f27bfa02b1354847d9aa246cf64293f6f8d298"
-  integrity sha512-f8LZZspPHpZjYuoe1bRNIZa1o5LlZHlT/eD5FVgM+f1mt05VM3BzwqzvX8eRNahXIkaET1PBH5I672xjLuoxpg==
+"@kickstartds/jsonschema2stackbit@^1.7.4":
+  version "1.7.4"
+  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2stackbit/-/jsonschema2stackbit-1.7.4.tgz#bd43e7932c4b8e207e85af40b82caa52f3efccfb"
+  integrity sha512-IKZCckXqOZeAj3xvm01t0KNOdxCA/kdlkaT1keXIzHglzvBEACu5JjaGaU0/OfswVJ8tfUOh9rqEb3RsIfN0Lg==
   dependencies:
-    "@kickstartds/jsonschema-utils" "3.0.11"
+    "@kickstartds/jsonschema-utils" "3.6.1"
     ajv "^8.12.0"
     object-traversal "^1.0.1"
+    pluralize-esm "~9.0.5"
 
-"@kickstartds/jsonschema2staticcms@^2.9.15":
-  version "2.9.15"
-  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2staticcms/-/jsonschema2staticcms-2.9.15.tgz#94ea3e37e7f0cd831d694723de3232e7396a21cb"
-  integrity sha512-r5WxqcwTZpJTmN0ZvKs4J5cLch7MA0ZOycPngd3lFCNmJ3CnyaN7pg6rlosypp6aNqNkGnC+XeNjOscY/3xtlg==
+"@kickstartds/jsonschema2staticcms@^2.9.35":
+  version "2.9.35"
+  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2staticcms/-/jsonschema2staticcms-2.9.35.tgz#0872a8a7d441cb88230fc88a6b573f4477261200"
+  integrity sha512-uJUZXVVl+ZPwYgNfFwAW6lHQcmjyyttDMpC6CS9WE1Y3CyBMANT12UKkfrLbfEcj8LJNlUdS/mJBOoF8moT8Yw==
   dependencies:
-    "@kickstartds/jsonschema-utils" "3.0.11"
+    "@kickstartds/jsonschema-utils" "3.6.1"
     ajv "^8.12.0"
     object-traversal "^1.0.1"
     pluralize "^8.0.0"
 
-"@kickstartds/jsonschema2storyblok@^1.5.20":
-  version "1.5.20"
-  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2storyblok/-/jsonschema2storyblok-1.5.20.tgz#f167c01c7b76adde5b61c29a5705922c2ddeb2cc"
-  integrity sha512-aEJV7wZMTYms6VGMSqPdNno3M7zJT+ApV9cGMjJWdSg6EjWh3Tusgz/u0X0Xp11UmR172Ds7NtgfbzO5T4TjFg==
+"@kickstartds/jsonschema2storyblok@^1.6.5":
+  version "1.6.5"
+  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2storyblok/-/jsonschema2storyblok-1.6.5.tgz#f8e376df999a732d4bfb6a270a01afbe2cfba16f"
+  integrity sha512-h+AHseOHkiU95LZ+qxlw2d66yJm/nH4iU+mXgG9QGsRZrQjchFmEgGtj2/xXMJWl9d0ZCsWDuTBfr9/R8jE0dQ==
   dependencies:
-    "@kickstartds/jsonschema-utils" "3.0.11"
+    "@kickstartds/jsonschema-utils" "3.6.1"
     ajv "^8.12.0"
     object-traversal "^1.0.1"
     uuid "~9.0.0"
 
-"@kickstartds/jsonschema2types@^1.2.0":
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2types/-/jsonschema2types-1.2.0.tgz#0f1d67d11679996f1fc24bb46cc8d3267f204d5f"
-  integrity sha512-xAiSwFzMr7kae59a3EXzkn9Iznm7Khp3rXm9oA29IaXKT/lC0rq9JPepwtxsr/AjkwY+YyKrq+Kxsl8pdT1QWA==
+"@kickstartds/jsonschema2types@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2types/-/jsonschema2types-1.2.3.tgz#a4580b772648682d1c07c37af5be7aabf38ee891"
+  integrity sha512-Dp41eGa4jkyahkB0NPYroixStSP/+f/01r5FuDIxdJK3ljU7FWTJGuYPNcToPN0gZxSHgaWASirFrAKUD5TgUg==
   dependencies:
     "@kickstartds/json-schema-to-typescript" "~13.1.20"
-    "@kickstartds/jsonschema-utils" "3.4.3"
+    "@kickstartds/jsonschema-utils" "3.6.1"
     ajv "^8.12.0"
     object-traversal "^1.0.1"
 
-"@kickstartds/jsonschema2uniform@^1.4.2":
-  version "1.4.2"
-  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2uniform/-/jsonschema2uniform-1.4.2.tgz#83e0944c3966ae534d0e9949c9b8452acc513ee4"
-  integrity sha512-j5PxO2KSg0lUN999Hb6INvUsIZGr757db+dWDgRSIP0GteYwzwVG1kpI/fmhY6xOLLQGevRdi+oe2eYvYdgeRQ==
+"@kickstartds/jsonschema2uniform@^1.4.22":
+  version "1.4.22"
+  resolved "https://registry.npmjs.org/@kickstartds/jsonschema2uniform/-/jsonschema2uniform-1.4.22.tgz#59c14e21f1b720add603ee457fc1a30c751f6737"
+  integrity sha512-SuPgC+PN2IaOJq7zugyXne2zUyJ5e4TLyClbYMBQAxrWnboRDEc8QzcxR7Pf9WyHuAKaO8w2F35c5tEN8hAWAA==
   dependencies:
-    "@kickstartds/jsonschema-utils" "3.0.11"
+    "@kickstartds/jsonschema-utils" "3.6.1"
     ajv "^8.12.0"
     change-case "^5.0.2"
 
@@ -6183,6 +6156,11 @@ pkg-conf@^2.1.0:
   dependencies:
     find-up "^2.0.0"
     load-json-file "^4.0.0"
+
+pluralize-esm@~9.0.5:
+  version "9.0.5"
+  resolved "https://registry.npmjs.org/pluralize-esm/-/pluralize-esm-9.0.5.tgz#002d75789f5d1ea695adebac56f5b94cd4f1aeab"
+  integrity sha512-Kb2dcpMsIutFw2hYrN0EhsAXOUJTd6FVMIxvNAkZCMQLVt9NGZqQczvGpYDxNWCZeCWLHUPxQIBudWzt1h7VVA==
 
 pluralize@^8.0.0:
   version "8.0.0"


### PR DESCRIPTION

<!-- GITHUB_RELEASE PR BODY: canary-version -->
<details>
  <summary>📦 Published PR as canary version: <code>3.4.0--canary.60.314.0</code></summary>
  <br />

  :sparkles: Test out this PR locally via:
  
  ```bash
  npm install kickstartds@3.4.0--canary.60.314.0
  # or 
  yarn add kickstartds@3.4.0--canary.60.314.0
  ```
</details>
<!-- GITHUB_RELEASE PR BODY: canary-version -->

<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
# Version

Published prerelease version: `v3.4.0-next.0`

<details>
  <summary>Changelog</summary>

  #### 🚀 Enhancement
  
  - Add task to create default objects for schemas [#60](https://github.com/kickstartDS/cli/pull/60) ([@julrich](https://github.com/julrich))
  
  #### Authors: 1
  
  - Jonas Ulrich ([@julrich](https://github.com/julrich))
</details>
<!-- GITHUB_RELEASE PR BODY: prerelease-version -->
